### PR TITLE
Fix get zips

### DIFF
--- a/get_zips.py
+++ b/get_zips.py
@@ -9,7 +9,7 @@ if not data_dir.exists():
     data_dir.mkdir(exist_ok=True)
 
 try:
-    for i in range(1, 2):
+    for i in range(1, 5):
         with request.urlopen(f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{i}.zip') as r, open(f'{data_dir}/spl_part{i}.zip', 'wb') as f:
                 f.write(r.read())
 except Exception as err:


### PR DESCRIPTION
Without the `finally` block, the code would not officially close.  It would download the files and then hang.  This corrects that issue.