### PR TITLE
Basic issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,12 @@
+---
+name: Issue
+about: Create a new issue
+---
+# Problem Statement
+[What needs to be done and why]
+
+# Criteria for Success
+[Measureable outcome if possible]
+
+# Additional Information
+[ways one might accomplish this task, links, documentation, alternatives, etc.]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+Fixes coderxio/dailymed-api#ISSUE NUMBER
+
+## Explanation
+[What did you change?]
+
+## Rationale
+[Why did you make the changes mentioned above? What alternatives did you consider?]
+
+## Tests
+1. What testing did you do?
+1. Attach testing logs inside a summary block:
+
+<details>
+<summary>testing logs</summary>
+
+```
+
+```
+</details>
+


### PR DESCRIPTION
Addresses: #5 

These are basic issue and PR templates for the repo. The templates will populate the github text editor when new issues or PRs are open, however, this will only work once they are merged into master. Other templates can be created under the `ISSUE_TEMPLATE` dir. I think these are a good start and will give some structure to working in the repo. 