### PR TITLE
Build status tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/coderxio/dailymed-api.svg?branch=master)](https://travis-ci.org/coderxio/dailymed-api)
+
 # DailyMed API
 
 This project uses poetry but its not necessary to install. It does require scrapy and python > 3.6.  This is really more of an experimental repo, there are a lot of caveats and really bugs with how this works but can serve as a starting point!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/coderxio/dailymed-api.svg?branch=master)](https://travis-ci.org/coderxio/dailymed-api)
+[<img src="https://img.shields.io/badge/slack-@oresoftware/npp-yellow.svg?logo=slack">](https://coderx.slack.com) [![Build Status](https://travis-ci.org/coderxio/dailymed-api.svg?branch=master)](https://travis-ci.org/coderxio/dailymed-api)
 
 # DailyMed API
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img src="https://img.shields.io/badge/slack-@oresoftware/npp-yellow.svg?logo=slack">](https://coderx.slack.com) [![Build Status](https://travis-ci.org/coderxio/dailymed-api.svg?branch=master)](https://travis-ci.org/coderxio/dailymed-api)
+[<img src="https://img.shields.io/badge/slack-@CodeRx-blue.svg?logo=slack">](https://coderx.slack.com) [![Build Status](https://travis-ci.org/coderxio/dailymed-api.svg?branch=master)](https://travis-ci.org/coderxio/dailymed-api)
 
 # DailyMed API
 


### PR DESCRIPTION
## Explanation
Add build tags to README.

## Rationale
Provides link to Slack channel and TravisCI build status.

## Tests
1. What testing did you do?
Pushed and viewed tags in branch README.

