### PR TITLE
23/download unzip loop

### DIFF
--- a/extract_zips.py
+++ b/extract_zips.py
@@ -3,27 +3,31 @@ import zipfile
 from pathlib import Path
 
 
-cwd = Path(__file__).parent.absolute()
-data_dir = cwd / 'data'
-partial_dir = data_dir / 'partial'
+def extract()
+    cwd = Path(__file__).parent.absolute()
+    data_dir = cwd / 'data'
+    partial_dir = data_dir / 'partial'
 
-if not partial_dir.exists():
-    partial_dir.mkdir(exist_ok=True)
+    if not partial_dir.exists():
+        partial_dir.mkdir(exist_ok=True)
 
-try:
-    ziped_dm_data = list(data_dir.glob('*.zip'))[0]
-except Exception:
-    raise Exception("Is there a zip file in the data dir?")
+    try:
+        ziped_dm_data = list(data_dir.glob('*.zip'))[0]
+    except Exception:
+        raise Exception("Is there a zip file in the data dir?")
 
-with zipfile.ZipFile(ziped_dm_data) as zip_ref:
-    unzip_count = 5000
+    with zipfile.ZipFile(ziped_dm_data) as zip_ref:
+        # unzip_count = 5000
 
-    for spl_zip in zip_ref.namelist():
-        if not unzip_count:
-            break
-        unzip_count -= 1
-        nested_zip_data = BytesIO(zip_ref.read(spl_zip))
-        with zipfile.ZipFile(nested_zip_data) as nested_zip:
-            for unzip_file in nested_zip.namelist():
-                if unzip_file.endswith('xml'):
-                    nested_zip.extract(unzip_file, partial_dir)
+        for spl_zip in zip_ref.namelist():
+            # if not unzip_count:
+            #     break
+            # unzip_count -= 1
+            nested_zip_data = BytesIO(zip_ref.read(spl_zip))
+            with zipfile.ZipFile(nested_zip_data) as nested_zip:
+                for unzip_file in nested_zip.namelist():
+                    if unzip_file.endswith('xml'):
+                        nested_zip.extract(unzip_file, partial_dir)
+
+if __name__ == '__main__':
+    extract()

--- a/extract_zips.py
+++ b/extract_zips.py
@@ -3,7 +3,7 @@ import zipfile
 from pathlib import Path
 
 
-def extract():
+def extract(depth=-1):
     cwd = Path(__file__).parent.absolute()
     data_dir = cwd / 'data'
     partial_dir = data_dir / 'partial'
@@ -17,12 +17,12 @@ def extract():
         raise Exception("Is there a zip file in the data dir?")
 
     with zipfile.ZipFile(ziped_dm_data) as zip_ref:
-        # unzip_count = 5000
+        unzip_count = depth
 
         for spl_zip in zip_ref.namelist():
-            # if not unzip_count:
-            #     break
-            # unzip_count -= 1
+            if not unzip_count:
+                break
+            unzip_count -= 1
             nested_zip_data = BytesIO(zip_ref.read(spl_zip))
             with zipfile.ZipFile(nested_zip_data) as nested_zip:
                 for unzip_file in nested_zip.namelist():
@@ -31,4 +31,4 @@ def extract():
 
 
 if __name__ == '__main__':
-    extract()
+    extract(depth)

--- a/extract_zips.py
+++ b/extract_zips.py
@@ -3,7 +3,7 @@ import zipfile
 from pathlib import Path
 
 
-def extract()
+def extract():
     cwd = Path(__file__).parent.absolute()
     data_dir = cwd / 'data'
     partial_dir = data_dir / 'partial'
@@ -28,6 +28,7 @@ def extract()
                 for unzip_file in nested_zip.namelist():
                     if unzip_file.endswith('xml'):
                         nested_zip.extract(unzip_file, partial_dir)
+
 
 if __name__ == '__main__':
     extract()

--- a/extract_zips.py
+++ b/extract_zips.py
@@ -31,4 +31,4 @@ def extract(depth=-1):
 
 
 if __name__ == '__main__':
-    extract(depth)
+    extract()

--- a/get_zips.py
+++ b/get_zips.py
@@ -8,10 +8,27 @@ from extract_zips import extract
 
 
 parser = argparse.ArgumentParser(description="Download and unzip SPL data.")
-parser.add_argument('--unzip', metavar='u', default='-1', type=int, help='Number of files to extract from SPL zip')
+parser.add_argument(
+            '--unzip',
+            metavar='u',
+            default='-1',
+            type=int,
+            help='Number of files to extract from SPL zip'
+        )
 download_or_select = parser.add_mutually_exclusive_group()
-download_or_select.add_argument('--download', metavar='d', default='4', type=int, help='Number of SPL files to download, max 4')
-download_or_select.add_argument('--select', metavar='s', type=int, help="Specific SPL file to download, i.e. 1, 2, 3 or 4")
+download_or_select.add_argument(
+                    '--download',
+                    metavar='d',
+                    default='4',
+                    type=int,
+                    help='Number of SPL files to download, max 4'
+                )
+download_or_select.add_argument(
+                    '--select',
+                    metavar='s',
+                    type=int,
+                    help="Specific SPL file to download, i.e. 1, 2, 3 or 4"
+                )
 
 args = parser.parse_args()
 depth = args.unzip
@@ -26,7 +43,14 @@ if not data_dir.exists():
     data_dir.mkdir(exist_ok=True)
 
 try:
-    if number == 4 and not spl:
+    if spl:
+        with request.urlopen(
+                    f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{spl}.zip') as r, open(  # noqa: E501
+                        f'{data_dir}/spl_part{spl}.zip', 'wb') as f:
+            shutil.copyfileobj(r, f)
+        extract(depth)
+        os.remove(f'{data_dir}/spl_part{spl}.zip')
+    elif number == 4:
         for i in range(1, 5):
             with request.urlopen(
                     f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{i}.zip') as r, open(  # noqa: E501
@@ -34,7 +58,7 @@ try:
                 shutil.copyfileobj(r, f)
             extract(depth)
             os.remove(f'{data_dir}/spl_part{i}.zip')
-    elif number < 4 and not spl:
+    elif number < 4:
         for i in range(1, number):
             with request.urlopen(
                         f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{i}.zip') as r, open(  # noqa: E501
@@ -42,13 +66,7 @@ try:
                 shutil.copyfileobj(r, f)
             extract(depth)
             os.remove(f'{data_dir}/spl_part{i}.zip')
-    elif spl:
-        with request.urlopen(
-                    f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{spl}.zip') as r, open(  # noqa: E501
-                        f'{data_dir}/spl_part{spl}.zip', 'wb') as f:
-            shutil.copyfileobj(r, f)
-        extract(depth)
-        os.remove(f'{data_dir}/spl_part{spl}.zip')
+
 
 except Exception as err:
     raise (f"Unable to perform request: {err}")

--- a/get_zips.py
+++ b/get_zips.py
@@ -1,5 +1,8 @@
 import urllib.request as request
 from pathlib import Path
+import os
+
+from extract_zips import extract
 
 
 cwd = Path(__file__).parent.absolute()
@@ -14,6 +17,9 @@ try:
                 f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{i}.zip') as r, open(  # noqa: E501
                     f'{data_dir}/spl_part{i}.zip', 'wb') as f:
             f.write(r.read())
+        extract()
+        os.remove(f'{data_dir}/spl_part{i}.zip')
+
 except Exception as err:
     raise (f"Unable to perform request: {err}")
 finally:

--- a/get_zips.py
+++ b/get_zips.py
@@ -21,13 +21,13 @@ download_or_select.add_argument(
                     metavar='d',
                     default='4',
                     type=int,
-                    help='Optional number of zip files to download, max 4.'
+                    help='Optional number of SPL zip files to download, max 4.'
                 )
 download_or_select.add_argument(
                     '--select',
                     metavar='s',
                     type=int,
-                    help="Optional spl zip file to download, i.e. 1, 2, 3 or 4"
+                    help="Optional SPL zip file to download, i.e. 1, 2, 3 or 4"
                 )
 
 args = parser.parse_args()

--- a/get_zips.py
+++ b/get_zips.py
@@ -13,7 +13,7 @@ parser.add_argument(
             metavar='u',
             default='-1',
             type=int,
-            help='Number of files to extract from SPL zip'
+            help='Optional number of files to extract from SPL zip.'
         )
 download_or_select = parser.add_mutually_exclusive_group()
 download_or_select.add_argument(
@@ -21,13 +21,13 @@ download_or_select.add_argument(
                     metavar='d',
                     default='4',
                     type=int,
-                    help='Number of SPL files to download, max 4'
+                    help='Optional number of SPL files to download, max 4.'
                 )
 download_or_select.add_argument(
                     '--select',
                     metavar='s',
                     type=int,
-                    help="Specific SPL file to download, i.e. 1, 2, 3 or 4"
+                    help="Optional SPL file to download, i.e. 1, 2, 3 or 4"
                 )
 
 args = parser.parse_args()

--- a/get_zips.py
+++ b/get_zips.py
@@ -8,7 +8,7 @@ from extract_zips import extract
 
 
 parser = argparse.ArgumentParser(description="Download and unzip SPL data.")
-parser.add_argument('--unzip', metavar='u', default='-1', type=int, help='Number of files to unzip from SPL')
+parser.add_argument('--unzip', metavar='u', default='-1', type=int, help='Number of files to extract from SPL zip')
 download_or_select = parser.add_mutually_exclusive_group()
 download_or_select.add_argument('--download', metavar='d', default='4', type=int, help='Number of SPL files to download, max 4')
 download_or_select.add_argument('--select', metavar='s', type=int, help="Specific SPL file to download, i.e. 1, 2, 3 or 4")

--- a/get_zips.py
+++ b/get_zips.py
@@ -2,8 +2,21 @@ import urllib.request as request
 from pathlib import Path
 import shutil
 import os
+import argparse
 
 from extract_zips import extract
+
+
+parser = argparse.ArgumentParser(description="Download and unzip SPL data.")
+parser.add_argument('--unzip', metavar='u', default='-1', type=int, help='Number of files to unzip from SPL')
+download_or_select = parser.add_mutually_exclusive_group()
+download_or_select.add_argument('--download', metavar='d', default='4', type=int, help='Number of SPL files to download, max 4')
+download_or_select.add_argument('--select', metavar='s', type=int, help="Specific SPL file to download, i.e. 1, 2, 3 or 4")
+
+args = parser.parse_args()
+depth = args.unzip
+number = args.download
+spl = args.select
 
 
 cwd = Path(__file__).parent.absolute()
@@ -13,13 +26,29 @@ if not data_dir.exists():
     data_dir.mkdir(exist_ok=True)
 
 try:
-    for i in range(1, 5):
+    if number == 4 and not spl:
+        for i in range(1, 5):
+            with request.urlopen(
+                    f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{i}.zip') as r, open(  # noqa: E501
+                        f'{data_dir}/spl_part{i}.zip', 'wb') as f:
+                shutil.copyfileobj(r, f)
+            extract(depth)
+            os.remove(f'{data_dir}/spl_part{i}.zip')
+    elif number < 4 and not spl:
+        for i in range(1, number):
+            with request.urlopen(
+                        f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{i}.zip') as r, open(  # noqa: E501
+                            f'{data_dir}/spl_part{i}.zip', 'wb') as f:
+                shutil.copyfileobj(r, f)
+            extract(depth)
+            os.remove(f'{data_dir}/spl_part{i}.zip')
+    elif spl:
         with request.urlopen(
-                f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{i}.zip') as r, open(  # noqa: E501
-                    f'{data_dir}/spl_part{i}.zip', 'wb') as f:
+                    f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{spl}.zip') as r, open(  # noqa: E501
+                        f'{data_dir}/spl_part{spl}.zip', 'wb') as f:
             shutil.copyfileobj(r, f)
-        extract()
-        os.remove(f'{data_dir}/spl_part{i}.zip')
+        extract(depth)
+        os.remove(f'{data_dir}/spl_part{spl}.zip')
 
 except Exception as err:
     raise (f"Unable to perform request: {err}")

--- a/get_zips.py
+++ b/get_zips.py
@@ -1,5 +1,6 @@
 import urllib.request as request
 from pathlib import Path
+import shutil
 import os
 
 from extract_zips import extract
@@ -16,7 +17,7 @@ try:
         with request.urlopen(
                 f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{i}.zip') as r, open(  # noqa: E501
                     f'{data_dir}/spl_part{i}.zip', 'wb') as f:
-            f.write(r.read())
+            shutil.copyfileobj(r, f)
         extract()
         os.remove(f'{data_dir}/spl_part{i}.zip')
 

--- a/get_zips.py
+++ b/get_zips.py
@@ -27,7 +27,7 @@ download_or_select.add_argument(
                     '--select',
                     metavar='s',
                     type=int,
-                    help="Optional zip file to download, i.e. 1, 2, 3 or 4"
+                    help="Optional spl zip file to download, i.e. 1, 2, 3 or 4"
                 )
 
 args = parser.parse_args()
@@ -50,23 +50,14 @@ try:
             shutil.copyfileobj(r, f)
         extract(depth)
         os.remove(f'{data_dir}/spl_part{spl_zip}.zip')
-    elif number == 4:
-        for i in range(1, 5):
+    else:
+        for i in range(1, number+1):
             with request.urlopen(
                     f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{i}.zip') as r, open(  # noqa: E501
                         f'{data_dir}/spl_part{i}.zip', 'wb') as f:
                 shutil.copyfileobj(r, f)
             extract(depth)
             os.remove(f'{data_dir}/spl_part{i}.zip')
-    elif number < 4:
-        for i in range(1, number):
-            with request.urlopen(
-                        f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{i}.zip') as r, open(  # noqa: E501
-                            f'{data_dir}/spl_part{i}.zip', 'wb') as f:
-                shutil.copyfileobj(r, f)
-            extract(depth)
-            os.remove(f'{data_dir}/spl_part{i}.zip')
-
 
 except Exception as err:
     raise (f"Unable to perform request: {err}")

--- a/get_zips.py
+++ b/get_zips.py
@@ -21,19 +21,19 @@ download_or_select.add_argument(
                     metavar='d',
                     default='4',
                     type=int,
-                    help='Optional number of SPL files to download, max 4.'
+                    help='Optional number of zip files to download, max 4.'
                 )
 download_or_select.add_argument(
                     '--select',
                     metavar='s',
                     type=int,
-                    help="Optional SPL file to download, i.e. 1, 2, 3 or 4"
+                    help="Optional zip file to download, i.e. 1, 2, 3 or 4"
                 )
 
 args = parser.parse_args()
 depth = args.unzip
 number = args.download
-spl = args.select
+spl_zip = args.select
 
 
 cwd = Path(__file__).parent.absolute()
@@ -43,13 +43,13 @@ if not data_dir.exists():
     data_dir.mkdir(exist_ok=True)
 
 try:
-    if spl:
+    if spl_zip:
         with request.urlopen(
-                    f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{spl}.zip') as r, open(  # noqa: E501
-                        f'{data_dir}/spl_part{spl}.zip', 'wb') as f:
+                    f'ftp://public.nlm.nih.gov/nlmdata/.dailymed/dm_spl_release_human_rx_part{spl_zip}.zip') as r, open(  # noqa: E501
+                        f'{data_dir}/spl_part{spl_zip}.zip', 'wb') as f:
             shutil.copyfileobj(r, f)
         extract(depth)
-        os.remove(f'{data_dir}/spl_part{spl}.zip')
+        os.remove(f'{data_dir}/spl_part{spl_zip}.zip')
     elif number == 4:
         for i in range(1, 5):
             with request.urlopen(


### PR DESCRIPTION
Fixes coderxio/dailymed-api#23

## Explanation
1. `get_zips.py` now calls `extract_zips.py`.  This allows for each SPL to be downloaded, extracted, and deleted before the next SPL is obtained.
2. `get_zips.py` reads and writes the SPL.zip file in chunks to prevent memory issues in low memory environments.
3. `get_zips.py` includes cmd line arguments to specific number of files to unzip, the number of SPLs to download or the specific SPL to download.
```
usage: get_zips.py [-h] [--unzip u] [--download d | --select s]

Download and unzip SPL data.

optional arguments:
  -h, --help    show this help message and exit
  --unzip u     Number of files to unzip from SPL
  --download d  Number of SPL files to download, max 4
  --select s    Specific SPL file to download, i.e. 1, 2, 3 or 4
```

## Rationale
To allow getting zips on the droplet and improve testing in dev environment.

## Tests
1. What testing did you do?
Downloaded SPL files via a variety of cmd line arguments
1. `python get_zips.py`
2. `python get_zips.py --unzip 2 --download 4`
3. `python get_zips.py --unzip 20 --download 1`
4. `python get_zips.py --unzip 2 --select 4`


