### PR TITLE
Actions poetry venv refactor

### DIFF
--- a/.github/workflows/dailymed_tests.yml
+++ b/.github/workflows/dailymed_tests.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         python-version: [3.7.9, 3.8]
 
+    env:
+      VIRTUAL_ENV: /opt/venv
+
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
@@ -23,20 +26,23 @@ jobs:
     - name: Setup
       run: pip install poetry
 
+    - name: List current host python installed dependencies
+      run: pip list
+
     - name: Create venv
-      uses: gabrielfalcao/pyenv-action@v5
-      with:
-        default: ${{ matrix.python }}
-  
-    - name: Install dependencies
-      run: |
-        poetry config virtualenvs.create false
-        poetry install
+      run: python -m venv $VIRTUAL_ENV
+
+    - name: Install app dependencies with poetry
+      run: poetry install
+
+    - name: Activate venv
+      run: echo $VIRTUAL_ENV >> $GITHUB_PATH
+
+    - name: List app dependencies
+      run: pip list
 
     - name: Styling
-      run: |
-        flake8
+      run: flake8
 
     - name: Test
-      run: |
-        python3 api/manage.py test api/
+      run: ./api/manage.py test

--- a/.github/workflows/dailymed_tests.yml
+++ b/.github/workflows/dailymed_tests.yml
@@ -36,7 +36,7 @@ jobs:
       run: poetry install
 
     - name: Activate venv
-      run: echo ${{ env.VIRTUAL_ENV }} >> $GITHUB_PATH
+      run: echo ${{ env.VIRTUAL_ENV }}/bin >> $GITHUB_PATH
 
     - name: List app dependencies
       run: pip list

--- a/.github/workflows/dailymed_tests.yml
+++ b/.github/workflows/dailymed_tests.yml
@@ -36,7 +36,7 @@ jobs:
       run: poetry install
 
     - name: Activate venv
-      run: echo $VIRTUAL_ENV >> $GITHUB_PATH
+      run: echo ${{ env.VIRTUAL_ENV }} >> $GITHUB_PATH
 
     - name: List app dependencies
       run: pip list

--- a/.github/workflows/dailymed_tests.yml
+++ b/.github/workflows/dailymed_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7.9, 3.8]
+        python-version: [ 3.8 ]
 
     env:
       VIRTUAL_ENV: /opt/venv
@@ -41,8 +41,8 @@ jobs:
     - name: List app dependencies
       run: pip list
 
-    - name: Styling
-      run: flake8
-
     - name: Test
       run: ./api/manage.py test
+
+    - name: Styling
+      run: flake8

--- a/.github/workflows/dailymed_tests.yml
+++ b/.github/workflows/dailymed_tests.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Setup
+    - name: Install poetry
       run: pip install poetry
 
     - name: List current host python installed dependencies


### PR DESCRIPTION
## Explanation
I adjusted how the venv gets setup in actions. Instead of using pyenv to setup the venv for application code, I refactored the action to mimic what is being done in docker. Only issues with this is apparently there is a bug in poetry with flake8 for python version < 3.8 which is causing the build to error out for python 3.7.9. I think we should consider simply using python 3.8 and refactoring docker to use this as well.

## Rationale
I think this makes for a slightly cleaner action setup and removes the dependency on pyenv.

## Tests
1. What testing did you do?
- see relevant action build log for pushes to this branch

